### PR TITLE
Add rule for health check to AdminSecurityGroup

### DIFF
--- a/cloudformation-template.yaml
+++ b/cloudformation-template.yaml
@@ -462,6 +462,14 @@ Resources:
           FromPort: '22'
           ToPort: '22'
           CidrIp: !Ref TrustedIpRange
+        - IpProtocol: tcp
+          FromPort: 4465
+          ToPort: 4465
+          SourceSecurityGroupId: !Select
+            - 0
+            - !GetAtt
+              - RuntimeLoadBalancer
+              - SecurityGroups
         - !If
           - CertificateNotProvided
           - CidrIp: !Ref TrustedIpRange


### PR DESCRIPTION
The AdminSecurityGroup is missing a rule for the health check port (4465). This leads to the admin target group being reported as 'unhealthy'. This PR fixes that.